### PR TITLE
Almost always kkc engine converts

### DIFF
--- a/senn/src/fcitx/stateful-ime.lisp
+++ b/senn/src/fcitx/stateful-ime.lisp
@@ -77,12 +77,15 @@
                                senn.im.mixin.engine:lookup)
   ((engine :initarg :engine)))
 
-(defun make-engine-ime (engine)
-  (make-instance 'stateful-engine-ime
-                 :convert-engine-impl engine
-                 :lookup-engine-impl engine
-                 :engine engine
-                 :state (make-initial-state)))
+(defun make-engine-ime (engine-runner)
+  (let ((engine (senn.im.mixin.engine:run-engine engine-runner)))
+    (make-instance 'stateful-engine-ime
+                   :convert-engine engine
+                   :convert-engine-runner engine-runner
+                   :lookup-engine engine
+                   :lookup-engine-runner engine-runner
+                   :engine engine
+                   :state (make-initial-state))))
 
 (defun close-engine-ime (ime)
   (senn.im.mixin.engine:kill-engine (slot-value ime 'engine)))

--- a/senn/src/fcitx/stateful-ime.lisp
+++ b/senn/src/fcitx/stateful-ime.lisp
@@ -75,17 +75,16 @@
                                senn.im:ime
                                senn.im.mixin.engine:convert
                                senn.im.mixin.engine:lookup)
-  ((engine :initarg :engine)))
+  ())
 
 (defun make-engine-ime (engine-runner)
-  (let ((engine (senn.im.mixin.engine:run-engine engine-runner)))
+  (let ((engine-store (senn.im.mixin.engine:make-engine-store
+                       :engine (senn.im.mixin.engine:run-engine
+                                engine-runner)
+                       :engine-runner engine-runner)))
     (make-instance 'stateful-engine-ime
-                   :convert-engine engine
-                   :convert-engine-runner engine-runner
-                   :lookup-engine engine
-                   :lookup-engine-runner engine-runner
-                   :engine engine
+                   :engine-store engine-store
                    :state (make-initial-state))))
 
 (defun close-engine-ime (ime)
-  (senn.im.mixin.engine:kill-engine (slot-value ime 'engine)))
+  (senn.im.mixin.engine:close-mixin ime))

--- a/senn/src/ibus/stateful-ime.lisp
+++ b/senn/src/ibus/stateful-ime.lisp
@@ -74,18 +74,16 @@
 (defclass stateful-engine-ime (stateful
                                senn.im:ime
                                senn.im.mixin.engine:convert
-                               senn.im.mixin.engine:lookup)
-  ((engine :initarg :engine)))
+                               senn.im.mixin.engine:lookup) ())
 
 (defun make-engine-ime (engine-runner)
-  (let ((engine (senn.im.mixin.engine:run-engine engine-runner)))
+  (let ((engine-store (senn.im.mixin.engine:make-engine-store
+                       :engine (senn.im.mixin.engine:run-engine
+                                engine-runner)
+                       :engine-runner engine-runner)))
     (make-instance 'stateful-engine-ime
-                   :convert-engine engine
-                   :convert-engine-runner engine-runner
-                   :lookup-engine engine
-                   :lookup-engine-runner engine-runner
-                   :engine engine
+                   :engine-store engine-store
                    :state (make-initial-state))))
 
 (defun close-engine-ime (ime)
-  (senn.im.mixin.engine:kill-engine (slot-value ime 'engine)))
+  (senn.im.mixin.engine:close-mixin ime))

--- a/senn/src/ibus/stateful-ime.lisp
+++ b/senn/src/ibus/stateful-ime.lisp
@@ -77,12 +77,15 @@
                                senn.im.mixin.engine:lookup)
   ((engine :initarg :engine)))
 
-(defun make-engine-ime (engine)
-  (make-instance 'stateful-engine-ime
-                 :convert-engine-impl engine
-                 :lookup-engine-impl engine
-                 :engine engine
-                 :state (make-initial-state)))
+(defun make-engine-ime (engine-runner)
+  (let ((engine (senn.im.mixin.engine:run-engine engine-runner)))
+    (make-instance 'stateful-engine-ime
+                   :convert-engine engine
+                   :convert-engine-runner engine-runner
+                   :lookup-engine engine
+                   :lookup-engine-runner engine-runner
+                   :engine engine
+                   :state (make-initial-state))))
 
 (defun close-engine-ime (ime)
   (senn.im.mixin.engine:kill-engine (slot-value ime 'engine)))

--- a/senn/src/im/mixin/engine.lisp
+++ b/senn/src/im/mixin/engine.lisp
@@ -79,8 +79,10 @@
       (make-engine :stream stream :process process)))
 
   (defun kill-engine (engine)
-    (ignore-errors
-      (ext:terminate-process (engine-process engine) t)))
+    (let ((process (engine-process engine)))
+      (ext:terminate-process process t)
+      ;; Wait the process to finish to prevent it from becoming a zombie.
+      (ext:external-process-wait process t)))
 
   (defun engine-send-recv (engine line)
     (let ((stream (engine-stream engine)))

--- a/senn/src/im/mixin/engine.lisp
+++ b/senn/src/im/mixin/engine.lisp
@@ -57,7 +57,7 @@
 
   (defun kill-engine (engine)
     (ignore-errors
-     (sb-ext:process-kill (engine-process engine) 9))))
+      (sb-ext:process-kill (engine-process engine) 9))))
 
 ;;;
 
@@ -80,7 +80,7 @@
 
   (defun kill-engine (engine)
     (ignore-errors
-     (ext:terminate-process (engine-process engine) t)))
+      (ext:terminate-process (engine-process engine) t)))
 
   (defun engine-send-recv (engine line)
     (let ((stream (engine-stream engine)))

--- a/senn/src/lib/fcitx-engine.lisp
+++ b/senn/src/lib/fcitx-engine.lisp
@@ -2,8 +2,7 @@
 
 (defun make-ime (engine-path)
   (senn.fcitx.stateful-ime:make-engine-ime
-   (senn.im.mixin.engine:run-engine
-    (senn.im.mixin.engine:make-engine-runner :program engine-path))))
+   (senn.im.mixin.engine:make-engine-runner :program engine-path)))
 
 (defun close-ime (ime)
   (log:info "IME closing...")

--- a/senn/src/lib/ibus-engine.lisp
+++ b/senn/src/lib/ibus-engine.lisp
@@ -2,9 +2,8 @@
 
 (defun make-ime ()
   (senn.ibus.stateful-ime:make-engine-ime
-   (senn.im.mixin.engine:run-engine
-    (senn.im.mixin.engine:make-engine-runner
-     :program "/usr/lib/senn/kkc-engine"))))
+   (senn.im.mixin.engine:make-engine-runner
+    :program "/usr/lib/senn/kkc-engine")))
 
 (defun close-ime (ime)
   (log:info "IME closing...")


### PR DESCRIPTION
Problem:
- The user can't convert an input by the kkc if the kkc-engine process dies.

Solution:
- Rerun a new kkc-engine process when an error occured:
- Rerun because the ime doesn't know wheher the process in which the error ocurred can still accept requests.